### PR TITLE
set a max height for images when displayed in the recommendations

### DIFF
--- a/src/components/paintings-page/recommendation/recommendation.module.scss
+++ b/src/components/paintings-page/recommendation/recommendation.module.scss
@@ -1,5 +1,5 @@
-@use '@variables' as *;
-@use '@mixins' as mixins;
+@use "@variables" as *;
+@use "@mixins" as mixins;
 
 .container {
   display: flex;
@@ -42,6 +42,7 @@
 
   img {
     height: auto;
+    max-height: 250px;
     width: 100%;
   }
 }


### PR DESCRIPTION
Images with larger heights were expanding beyond their container. I set a max-height to the image only when displayed in the recommendations list.